### PR TITLE
Upgrade to Vaadin 25.1.0-alpha10 with Spring Boot 4 and Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,25 +3,29 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <!-- Project from https://start.vaadin.com/ -->
-    <groupId>org.vaadin.artur.hilla</groupId>
-    <artifactId>hilla-live-db</artifactId>
-    <name>hilla-live-db</name>
+    <groupId>org.vaadin.artur</groupId>
+    <artifactId>livedb</artifactId>
+    <name>livedb</name>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-
-    <properties>
-        <java.version>17</java.version>
-        <vaadin.version>24.8.0</vaadin.version>
-    </properties>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>4.0.0</version>
+        <relativePath/>
     </parent>
 
+    <properties>
+        <java.version>21</java.version>
+        <vaadin.version>25.1.0-alpha10</vaadin.version>
+    </properties>
+
     <repositories>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+        </repository>
         <repository>
             <id>Vaadin Directory</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
@@ -44,14 +48,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.21.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
@@ -67,6 +74,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-r2dbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -106,35 +118,25 @@
     </dependencies>
 
     <build>
-        <defaultGoal>spring-boot:run</defaultGoal>
+        <defaultGoal>spring-boot:test-run</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>production</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>dev.hilla</groupId>
-                        <artifactId>hilla-maven-plugin</artifactId>
-                        <version>${hilla.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-frontend</goal>
-                                    <goal>build-frontend</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/org/vaadin/artur/livedb/Application.java
+++ b/src/main/java/org/vaadin/artur/livedb/Application.java
@@ -2,14 +2,16 @@ package org.vaadin.artur.livedb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.theme.lumo.Lumo;
 
 @SpringBootApplication
 @Push
-public class Application extends SpringBootServletInitializer implements AppShellConfigurator {
+@StyleSheet(Lumo.STYLESHEET)
+public class Application implements AppShellConfigurator {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/org/vaadin/artur/livedb/ItemService.java
+++ b/src/main/java/org/vaadin/artur/livedb/ItemService.java
@@ -14,8 +14,8 @@ import org.vaadin.artur.livedb.data.ItemRepository;
 import reactor.core.publisher.Mono;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
-import com.vaadin.signals.ListSignal;
-import com.vaadin.signals.Signal;
+import com.vaadin.flow.signals.shared.SharedListSignal;
+import com.vaadin.flow.signals.Signal;
 
 @Service
 @AnonymousAllowed
@@ -23,7 +23,7 @@ public class ItemService {
 
     private final PostgresqlConnection connection;
 
-    private final ListSignal<Item> items = new ListSignal<>(Item.class);
+    private final SharedListSignal<Item> items = new SharedListSignal<>(Item.class);
 
     private final ItemRepository itemRepository;
 
@@ -36,7 +36,7 @@ public class ItemService {
         connection = pooledConnection.unwrap();
     }
 
-    private ListSignal<Item> initItems() {
+    private SharedListSignal<Item> initItems() {
         if (!inited) {
             inited = true;
 
@@ -63,17 +63,17 @@ public class ItemService {
                         break;
                     case "item_updated":
                         itemRepository.findById(id).doOnNext(updateItem -> {
-                            items.value().stream()
-                                    .filter(existingItem -> existingItem.value().getId() == updateItem.getId())
+                            items.peek().stream()
+                                    .filter(existingItem -> existingItem.peek().getId() == updateItem.getId())
                                     .findFirst()
                                     .ifPresent(existingItem -> {
-                                        existingItem.value(updateItem);
+                                        existingItem.set(updateItem);
                                     });
                         }).subscribe();
                         break;
                     case "item_deleted":
-                        items.value().stream()
-                                .filter(existingItem -> existingItem.value().getId() == id)
+                        items.peek().stream()
+                                .filter(existingItem -> existingItem.peek().getId() == id)
                                 .findFirst()
                                 .ifPresent(existingItem -> {
                                     items.remove(existingItem);
@@ -93,7 +93,7 @@ public class ItemService {
     }
 
     @NonNull
-    public ListSignal<Item> getItems() {
+    public SharedListSignal<Item> getItems() {
         // This must be lazily inited because signals are not available during
         // @PostConstruct
         return initItems();

--- a/src/main/java/org/vaadin/artur/livedb/MainView.java
+++ b/src/main/java/org/vaadin/artur/livedb/MainView.java
@@ -4,26 +4,26 @@ import java.util.List;
 
 import org.vaadin.artur.livedb.data.Item;
 
-import com.vaadin.flow.component.ComponentEffect;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
-import com.vaadin.signals.ListSignal;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.shared.SharedListSignal;
 
 @Route("")
 public class MainView extends Div {
 
     public MainView(ItemService itemService) {
         Grid<Item> grid = new Grid<>(Item.class);
-        ComponentEffect.effect(grid, () -> {
+        Signal.effect(grid, () -> {
             grid.setItems(toList(itemService.getItems()));
         });
         add(grid);
 
     }
 
-    private static List<Item> toList(ListSignal<Item> itemsSignal) {
-        return itemsSignal.value().stream()
-                .map(item -> item.value()).toList();
+    private static List<Item> toList(SharedListSignal<Item> itemsSignal) {
+        return itemsSignal.get().stream()
+                .map(item -> item.get()).toList();
     }
 }


### PR DESCRIPTION
Migrate from Vaadin 24.8/Spring Boot 3.5/Java 17 to Vaadin 25.1 alpha/Spring Boot 4/Java 21. Key changes: ListSignal to SharedListSignal, ComponentEffect.effect to Signal.effect, .value() to .get()/.set(), add Lumo stylesheet opt-in, replace hilla-maven-plugin with vaadin-maven-plugin, and add testcontainers-bom for SB4 compat.